### PR TITLE
Fix if method_exists

### DIFF
--- a/src/GithubArchiveInstaller.php
+++ b/src/GithubArchiveInstaller.php
@@ -104,7 +104,7 @@ class GithubArchiveInstaller implements PluginInterface, EventSubscriberInterfac
 	public function getPackageFromOperation( OperationInterface $operation ) {
 		if (
 			$operation instanceof UpdateOperation
-			|| method_exists($operation, 'getJobType' && 'update' === $operation->getJobType())
+			|| (method_exists($operation, 'getJobType') && 'update' === $operation->getJobType())
 		) {
 			/**
 			 * Operation is an update operation.


### PR DESCRIPTION
I think there was a typo in the if statement which resulted in a `Call to undefined method Composer\DependencyResolver\Operation\InstallOperation::getJobType()`