### PR TITLE
Correct misplaced condition

### DIFF
--- a/src/GithubArchiveInstaller.php
+++ b/src/GithubArchiveInstaller.php
@@ -104,7 +104,7 @@ class GithubArchiveInstaller implements PluginInterface, EventSubscriberInterfac
 	public function getPackageFromOperation( OperationInterface $operation ) {
 		if (
 			$operation instanceof UpdateOperation
-			|| method_exists($operation, 'getJobType' && 'update' === $operation->getJobType())
+			|| ( method_exists( $operation, 'getJobType' ) && 'update' === $operation->getJobType() )
 		) {
 			/**
 			 * Operation is an update operation.


### PR DESCRIPTION
Last time I put it inside of the `method_exists` call by accident.